### PR TITLE
A few minor changes for gopacket usage.

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,17 +45,17 @@ func main() {
 
 	// Our IP header... not used, but necessary for TCP checksumming.
 	ip := &layers.IPv4{
-		SrcIP: localIP(dstip),
-		DstIP: dstip,
+		SrcIP:    localIP(dstip),
+		DstIP:    dstip,
 		Protocol: layers.IPProtocolTCP,
 	}
 	// Our TCP header
 	tcp := &layers.TCP{
-		SrcPort:  45677,
-		DstPort:  dport,
-		Seq:      1105024978,
-		SYN:      true,
-		Window:   14600,
+		SrcPort: 45677,
+		DstPort: dport,
+		Seq:     1105024978,
+		SYN:     true,
+		Window:  14600,
 	}
 	tcp.SetNetworkLayerForChecksum(ip)
 


### PR DESCRIPTION
1) gofmt formatting
2) use gopacket.SerializeLayers to do simpler serialization
3) add FixLengths to serialize options, which fixes TCP Length
4) remove IPv4 fragment offset, since this is not a fragmented packet
5) maybe some other stuff I forgot?

BTW, if you want to see just the changes that do something, you can commit a gofmt first, then pull this in ;)
